### PR TITLE
feat/archive-scrape: find and download items from the Blissymoblics Internet Archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,40 @@ Run the following command to lint all python scripts:
 
 All utility functions are in `utils` directory.
 
+### Search and Download PDFs and JP2 zip files from the Blissymbolics archive (utils/internet_archive_scrape.py)
+
+This script searches and downloads files from the [Blissymbolics collection](https://archive.org/details/blissymbolics)
+in the Internet Archive.  The [Archive Data Extraction Feasibility](https://docs.google.com/document/d/1i9W_IXHtaaoWJD9IMA4S0d9bbYdMaCWNJRSQtFbxEhI/edit#heading=h.jszt9hbxhtuf)
+document provides a five point rating scale of the archive's data in terms of how 
+useful it will be for training.  The script searches and downloads archive data with ratings of 2/5 and higher based on what is noted in the feasibility document.
+
+The script contains partial titles taken from the [Archive Data Extraction Feasibility](https://docs.google.com/document/d/1i9W_IXHtaaoWJD9IMA4S0d9bbYdMaCWNJRSQtFbxEhI/edit#heading=h.jszt9hbxhtuf) document. Each item in the Blissymbolics collection
+that matches a title is used to download any PDF and any zip file of JP2 images associated with that item.
+
+The PDF and zip files are downloaded to a subdirectory within the current directory.
+Each item's identifier is used to create a subdirectory whose name is the same as the identifier.  The item's PDF and JP2 zip file are downloaded to that subdirectory.
+
+Note that the downloader is smart enough not to download a file that was downloaded
+on a previous run.  It checks if the file has matching dates and sizes and, if so,
+does not download it again.  It instead reports that it is skipping that file.
+
+**Prerequisite**: This script depends on the Internet Archive's `internetarchive`
+python library.  It is recommended to first create and activate a virtual
+environment and then install the library, for example:
+
+```
+$ python -m venv IA_ENV
+$ source IA_ENV/bin/activate
+$ pip install internetarchive
+```
+Complete documentation for the library is available at [The Internet
+Archive Python Library](https://archive.org/developers/internetarchive/index.html) documentation site.
+
+**Usage**: python internet_archive_scrape.py
+
+**Returns**: None.  However, folders with names like `OTUED_8-2-1-9-1` are created,
+containing `OTUED_8-2-1-9-1.pdf` and `OTUED_8-2-1-9-1_jp2.zip` files.
+
 ### Scale down images (utils/scale_down_images.py)
 
 This script scales down JPG and PNG images in a directory to a specified size while maintaining their aspect ratios. 

--- a/utils/internet_archive_scrape.py
+++ b/utils/internet_archive_scrape.py
@@ -31,7 +31,7 @@ def search_title(item_title, collection):
     found.
 
     The `item_title` argument is a case insenstive string that can match all or
-    part of the title of an item in the collection.  For example 'newsletter' 
+    part of the title of an item in the collection.  For example 'newsletter'
     will match both 'Newsletter' and 'Blissword Newsletter'.
 
     The `collection` is a string naming the collection in which the item

--- a/utils/internet_archive_scrape.py
+++ b/utils/internet_archive_scrape.py
@@ -71,7 +71,10 @@ def search_and_download(item_title, collection='blissymbolics'):
     for item in search_title(item_title, collection):
         print('Item: ' + str(item))
         ident = item['identifier']
-        download(ident, files=[f'{ident}.pdf', f'{ident}_jp2.zip'], verbose=True)
+        try:
+          download(ident, files=[f'{ident}.pdf', f'{ident}_jp2.zip'], verbose=True)
+        except Exception as e:
+          print(f'Error downloading {ident}: {e}')
 
 
 # Exact title matches -- retrieves only the items with the given title string.

--- a/utils/internet_archive_scrape.py
+++ b/utils/internet_archive_scrape.py
@@ -72,9 +72,9 @@ def search_and_download(item_title, collection='blissymbolics'):
         print('Item: ' + str(item))
         ident = item['identifier']
         try:
-          download(ident, files=[f'{ident}.pdf', f'{ident}_jp2.zip'], verbose=True)
+            download(ident, files=[f'{ident}.pdf', f'{ident}_jp2.zip'], verbose=True)
         except Exception as e:
-          print(f'Error downloading {ident}: {e}')
+            print(f'Error downloading {ident}: {e}')
 
 
 # Exact title matches -- retrieves only the items with the given title string.

--- a/utils/internet_archive_scrape.py
+++ b/utils/internet_archive_scrape.py
@@ -63,7 +63,7 @@ def search_and_download(item_title, collection='blissymbolics'):
     same as the identifier.  Theitem's PDF and JP2 zip file are downloaded to
     that subdirectory.
 
-    Note that the downloader is smart enough not to download a file that was has
+    Note that the downloader is smart enough not to download a file that was
     downloaded on a previous run.  It appears to check if the files are the same
     and, if so, does not download it again.  It instead reports that it is
     skipping that file.
@@ -80,11 +80,11 @@ def search_and_download(item_title, collection='blissymbolics'):
 # - "Sexual" and "tell" 4/5
 # - "Communicating with" 3/5
 # - "Communicating together" 2/5
-search_and_download('newspaper')
-search_and_download('Sexual')
-search_and_download('tell')
-search_and_download('Communicating with')
-search_and_download('Communicating together')
+search_and_download('Symbol Users\' Newspaper')
+search_and_download('Being Sexual: An Illustrated Series on Sexuality and Relationships')
+search_and_download('After You Tell')
+search_and_download('Communicating with Blissymbolics')
+search_and_download('Communicating Together')
 
 # There are many items with "newsletter" in their title and this single search
 # retrieves all of them.  The ratings in parentheses are Will's ratings in terms
@@ -92,6 +92,6 @@ search_and_download('Communicating together')
 # - Newsletter (3.5/5)
 # - BlissWorld Newsletter (3/5)
 # - Symbol Coordination Committee Newsletter (2/5)
-search_and_download('newsletter')
+search_and_download('Newsletter')
 
 print('Done!')

--- a/utils/internet_archive_scrape.py
+++ b/utils/internet_archive_scrape.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2023, Inclusive Design Institute
+#
+# Licensed under the BSD 3-Clause License. You may not use this file except
+# in compliance with this License.
+#
+# You may obtain a copy of the BSD 3-Clause License at
+# https://github.com/inclusive-design/baby-bliss-bot/blob/main/LICENSE
+
+"""
+Script for searching and downloading items from the Blissymbolics archive (the
+Blissymbolics collection in the Internet Archive).
+
+This script depends on the Internet Archive's `internetarchive` python library.
+It is recommended to first create and activate a virtual environment and then
+install the library:
+  $ python -m venv IA_ENV
+  $ source IA_ENV/bin/activate
+  $ pip install internetarchive
+
+Complete documentation for the library is available at their "The Internet
+Archive Python Library" documentation site:
+https://archive.org/developers/internetarchive/index.html
+
+"""
+from internetarchive import search_items, download
+
+
+def search_title(item_title, collection):
+    """
+    Search for the given title in the given collection and return the items
+    found.
+
+    The `item_title` argument is a case insenstive string that can match all or
+    part of the title of an item in the collection.  For example 'newsletter' 
+    will match both 'Newsletter' and 'Blissword Newsletter'.
+
+    The `collection` is a string naming the collection in which the item
+    resides.  For examplele, 'blissymbolics'.
+
+    A `Search` object is returned.
+    """
+    query = f'title:"{item_title}" collection:{collection}'
+    print(f'Query: {query}')
+    return search_items(query)
+
+
+def search_and_download(item_title, collection='blissymbolics'):
+    """
+    Search for a given item title and, if found, download its associated items
+    to the current directory.
+
+    The `item_title` argument is a case insenstive string that can match all or
+    part of the title of an item in the collection.  For example 'newsletter'
+    will match 'Newsletter' and 'Blissword Newsletter'.
+
+    The `collection` is a string naming the collection in which the item
+    resides.  It defaults to 'blissymbolics'.
+
+    Each item with the title in the collection is used to download any PDF and
+    any zip file of JP2 images associated with that item.  The PDF and zip
+    files are downloaded to a subdirectory within the current directory.
+    Each item's identifier is used to create a subdirectory whose name is the
+    same as the identifier.  Theitem's PDF and JP2 zip file are downloaded to
+    that subdirectory.
+
+    Note that the downloader is smart enough not to download a file that was has
+    downloaded on a previous run.  It appears to check if the files are the same
+    and, if so, does not download it again.  It instead reports that it is
+    skipping that file.
+    """
+    for item in search_title(item_title, collection):
+        print('Item: ' + str(item))
+        ident = item['identifier']
+        download(ident, files=[f'{ident}.pdf', f'{ident}_jp2.zip'], verbose=True)
+
+
+# Exact title matches -- retrieves only the items with the given title string.
+# For these items, the ratings in terms of quantity of Bliss are:
+# - "newspaper" 5/5
+# - "Sexual" and "tell" 4/5
+# - "Communicating with" 3/5
+# - "Communicating together" 2/5
+search_and_download('newspaper')
+search_and_download('Sexual')
+search_and_download('tell')
+search_and_download('Communicating with')
+search_and_download('Communicating together')
+
+# There are many items with "newsletter" in their title and this single search
+# retrieves all of them.  The ratings in parentheses are Will's ratings in terms
+# of quantity of Bliss.
+# - Newsletter (3.5/5)
+# - BlissWorld Newsletter (3/5)
+# - Symbol Coordination Committee Newsletter (2/5)
+search_and_download('newsletter')
+
+print('Done!')


### PR DESCRIPTION
## Description

Add a utility script that searches and downloads data from the [Blissymbolics Internet Archive](https://archive.org/details/blissymbolics) based on the research documented in the [Archive Data Extraction Feasibility](https://docs.google.com/document/d/1i9W_IXHtaaoWJD9IMA4S0d9bbYdMaCWNJRSQtFbxEhI/edit#) document.

## Steps to test

1. Set up a python virtual environment and install the Internet Archive's python library
2. Run the extraction script

More details are provided in the README.

**Expected behavior:**

The relevant PDF and JP2 zip files are downloaded to the local directory.

NOTE:  The size of the full download is approximately 4 gigabytes.

